### PR TITLE
Implement systemCartridgeRumble to trigger iOS haptic feedback

### DIFF
--- a/GBADeltaCore/Bridge/GBAEmulatorBridge.mm
+++ b/GBADeltaCore/Bridge/GBAEmulatorBridge.mm
@@ -545,8 +545,15 @@ int systemGetSensorZ()
     return sensorZ;
 }
 
-void systemCartridgeRumble(bool)
+void systemCartridgeRumble(bool active)
 {
+    if (active)
+    {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            UIImpactFeedbackGenerator *generator = [[UIImpactFeedbackGenerator alloc] initWithStyle:UIImpactFeedbackStyleMedium];
+            [generator impactOccurred];
+        });
+    }
 }
 
 void systemGbPrint(uint8_t * _puiData,


### PR DESCRIPTION
WarioWare: Twisted! uses GPIO Bit 3 to toggle a rumble motor in the cartridge. VBA-M already calls systemCartridgeRumble() with the correct bool state, but the function was previously a no-op.

This change fires UIImpactFeedbackGenerator on the main thread when rumble is activated, routing cartridge rumble through the iPhone's Taptic Engine.

Closes rileytestut/Delta#481